### PR TITLE
chore: added network module to koin, and unit tests as well

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:name=".base.BaseApplication"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity android:name=".MainActivity">

--- a/app/src/main/java/com/picpay/desafio/android/MainActivity.kt
+++ b/app/src/main/java/com/picpay/desafio/android/MainActivity.kt
@@ -6,41 +6,18 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import okhttp3.OkHttpClient
+import org.koin.core.KoinComponent
+import org.koin.core.inject
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 
-class MainActivity : AppCompatActivity(R.layout.activity_main) {
+class MainActivity : AppCompatActivity(R.layout.activity_main), KoinComponent {
 
+    private val service: PicPayService by inject()
     private lateinit var recyclerView: RecyclerView
     private lateinit var progressBar: ProgressBar
     private lateinit var adapter: UserListAdapter
-
-    private val url = "https://609a908e0f5a13001721b74e.mockapi.io/picpay/api/"
-
-    private val gson: Gson by lazy { GsonBuilder().create() }
-
-    private val okHttp: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .build()
-    }
-
-    private val retrofit: Retrofit by lazy {
-        Retrofit.Builder()
-            .baseUrl(url)
-            .client(okHttp)
-            .addConverterFactory(GsonConverterFactory.create(gson))
-            .build()
-    }
-
-    private val service: PicPayService by lazy {
-        retrofit.create(PicPayService::class.java)
-    }
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/java/com/picpay/desafio/android/base/BaseApplication.kt
+++ b/app/src/main/java/com/picpay/desafio/android/base/BaseApplication.kt
@@ -1,0 +1,27 @@
+package com.picpay.desafio.android.base
+
+import android.app.Application
+import com.picpay.desafio.android.di.networkModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+
+class BaseApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        setupKoin()
+    }
+
+    private fun setupKoin() {
+        startKoin {
+            androidLogger()
+            androidContext(this@BaseApplication)
+            modules(
+                listOf(
+                    networkModule
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/picpay/desafio/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/picpay/desafio/android/di/NetworkModule.kt
@@ -1,0 +1,43 @@
+package com.picpay.desafio.android.di
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.picpay.desafio.android.PicPayService
+import com.picpay.desafio.android.utils.Constants.BASE_URL
+import com.picpay.desafio.android.utils.Constants.DEFAULT_TIMEOUT
+import org.koin.dsl.module
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+val networkModule = module {
+
+    single {
+        val okHttpClient = OkHttpClient().newBuilder()
+            .connectTimeout(DEFAULT_TIMEOUT, TimeUnit.SECONDS)
+            .readTimeout(DEFAULT_TIMEOUT, TimeUnit.SECONDS)
+            .writeTimeout(DEFAULT_TIMEOUT, TimeUnit.SECONDS)
+
+        okHttpClient.build()
+    }
+
+    single {
+        GsonBuilder().create()
+    }
+
+    single {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(get<OkHttpClient>())
+            .addConverterFactory(GsonConverterFactory.create(get<Gson>()))
+            .build()
+    }
+
+    single {
+        getPicPayService(get<Retrofit>())
+    }
+}
+
+private fun getPicPayService(retrofit: Retrofit): PicPayService =
+    retrofit.create(PicPayService::class.java)

--- a/app/src/main/java/com/picpay/desafio/android/utils/Constants.kt
+++ b/app/src/main/java/com/picpay/desafio/android/utils/Constants.kt
@@ -1,0 +1,7 @@
+package com.picpay.desafio.android.utils
+
+object Constants {
+
+    const val DEFAULT_TIMEOUT = 60L
+    const val BASE_URL = "https://609a908e0f5a13001721b74e.mockapi.io/picpay/api/"
+}

--- a/app/src/test/java/com/picpay/desafio/android/di/GeneralModulesTest.kt
+++ b/app/src/test/java/com/picpay/desafio/android/di/GeneralModulesTest.kt
@@ -1,0 +1,27 @@
+package com.picpay.desafio.android.di
+
+import org.junit.After
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.check.checkModules
+
+class GeneralModulesTest: KoinTest {
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `GIVEN koin modules WHEN koin application is started it THEN it should instantiate these modules correctly`() {
+        val koinModules = listOf(
+            networkModule
+        )
+
+        startKoin {
+            modules(koinModules)
+        }.checkModules()
+    }
+}

--- a/app/src/test/java/com/picpay/desafio/android/di/NetworkModuleTest.kt
+++ b/app/src/test/java/com/picpay/desafio/android/di/NetworkModuleTest.kt
@@ -1,0 +1,62 @@
+package com.picpay.desafio.android.di
+
+import com.google.gson.Gson
+import com.picpay.desafio.android.PicPayService
+import com.picpay.desafio.android.utils.Constants
+import org.junit.After
+import org.junit.Before
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import okhttp3.OkHttpClient
+import org.junit.Assert
+import org.junit.Test
+import retrofit2.Retrofit
+
+class NetworkModuleTest : KoinTest {
+
+    private val retrofit: Retrofit by inject()
+    private val okHttpClient: OkHttpClient by inject()
+    private val gson: Gson by inject()
+    private val service: PicPayService by inject()
+
+    @Before
+    fun setup() {
+        startKoin {
+            modules(networkModule)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `WHEN koin application is started it SHOULD instantiate Retrofit`() {
+        Assert.assertNotNull(retrofit)
+    }
+
+    @Test
+    fun `WHEN koin application is started it SHOULD instantiate PicPayService`() {
+        Assert.assertNotNull(service)
+    }
+
+    @Test
+    fun `WHEN koin application is started it SHOULD instantiate Gson`() {
+        Assert.assertNotNull(gson)
+    }
+
+    @Test
+    fun `WHEN koin application is started it SHOULD instantiate OkHttpClient`() {
+        Assert.assertNotNull(okHttpClient)
+    }
+
+    @Test
+    fun `WHEN okHttpClient is instantiated it SHOULD have connect, write and read timeouts set with correct values`() {
+        Assert.assertTrue(okHttpClient.connectTimeoutMillis == (Constants.DEFAULT_TIMEOUT * 1000).toInt())
+        Assert.assertTrue(okHttpClient.readTimeoutMillis == (Constants.DEFAULT_TIMEOUT * 1000).toInt())
+        Assert.assertTrue(okHttpClient.writeTimeoutMillis == (Constants.DEFAULT_TIMEOUT * 1000).toInt())
+    }
+}


### PR DESCRIPTION
Started to work with dependency injection (Koin) to take care of the app instances.
At this point, the only module created is networkModule that contains retrofit, okhttp and others to reduce boilerplate on main activity and allow scalability.