### PR TITLE
feat: adjusted recyclerview inside nested scroll view to mantain scro…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxjava:$rxjava_version"
     implementation "io.reactivex.rxjava2:rxandroid:$rxandroid_version"
 
+    implementation "androidx.recyclerview:recyclerview:1.2.0"
+
     implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"

--- a/app/src/main/java/com/picpay/desafio/android/presentation/home/AgendaFragment.kt
+++ b/app/src/main/java/com/picpay/desafio/android/presentation/home/AgendaFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.lifecycle.Observer
-import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.picpay.desafio.android.R
 import com.picpay.desafio.android.base.BaseFragment
 import com.picpay.desafio.android.databinding.FragmentAgendaBinding
@@ -16,19 +16,30 @@ class AgendaFragment: BaseFragment<FragmentAgendaBinding>() {
     private val viewModel by viewModel<AgendaViewModel>()
     private lateinit var adapter: UserListAdapter
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.userListProgressBar.visibility = View.VISIBLE
         adapter = UserListAdapter()
-        binding.recyclerView.adapter = adapter
-        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
-
+        setupView()
+        setupRecyclerView()
         setObservers()
     }
 
     override fun getViewBinding(): FragmentAgendaBinding {
         return FragmentAgendaBinding.inflate(layoutInflater)
+    }
+
+    private fun setupView() {
+        binding.userListProgressBar.visibility = View.VISIBLE
+    }
+
+    private fun setupRecyclerView() {
+        adapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
+
+        binding.recyclerView.adapter = adapter
     }
 
     private fun setObservers() {
@@ -41,7 +52,8 @@ class AgendaFragment: BaseFragment<FragmentAgendaBinding>() {
                         adapter.users = it.value
                     }
 
-                    is ResponseHandler.Loading -> {}
+                    is ResponseHandler.Loading -> {
+                    }
 
                     is ResponseHandler.Error -> {
                         val message = getString(R.string.error)

--- a/app/src/main/res/layout/fragment_agenda.xml
+++ b/app/src/main/res/layout/fragment_agenda.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/container_nested_scroll_view"
     android:background="@color/colorPrimaryDark">
 
     <LinearLayout
@@ -34,6 +35,7 @@
                 android:layout_marginTop="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:listitem="@layout/list_item_user" />
 


### PR DESCRIPTION
Solving contacts list rotation problem with 2 things:

- Added recyclerview 1.2.0  and set StateRestorationPolicy to PREVENT_WHEN_EMPTY, that will prevent state restoration when adapter is empty;
- Like it's inside a nested scroll view, just had to set an id for it to retain scroll position :)

https://user-images.githubusercontent.com/35370634/118210657-2285cc80-b441-11eb-844f-7408c138545f.mp4

