### PR TITLE
fix: solving possible crashes on nullability

### DIFF
--- a/app/src/main/java/com/picpay/desafio/android/data/contacts/data/local/entity/UserLocal.kt
+++ b/app/src/main/java/com/picpay/desafio/android/data/contacts/data/local/entity/UserLocal.kt
@@ -6,7 +6,7 @@ import androidx.room.PrimaryKey
 @Entity
 data class UserLocal(
     @PrimaryKey val id: Int,
-    val img: String?,
+    val img: String,
     val name: String,
     val username: String
 )

--- a/app/src/main/java/com/picpay/desafio/android/data/contacts/data/mapper/UserMapper.kt
+++ b/app/src/main/java/com/picpay/desafio/android/data/contacts/data/mapper/UserMapper.kt
@@ -7,7 +7,7 @@ import com.picpay.desafio.android.domain.entity.User
 fun UserResponse.toDomainModel(): User =
     User(
         id = this.id,
-        img = this.img,
+        img = if(this.img.isNullOrBlank()) "Empty image url" else this.img,
         name = this.name ?: "Empty name",
         username = this.username ?: "Empty username"
     )
@@ -15,7 +15,7 @@ fun UserResponse.toDomainModel(): User =
 fun UserResponse.toDatabaseModel(): UserLocal =
     UserLocal(
         id = this.id,
-        img = this.img,
+        img = if(this.img.isNullOrBlank()) "Empty image url" else this.img,
         name = this.name ?: "Empty name",
         username = this.username ?: "Empty username"
     )

--- a/app/src/main/java/com/picpay/desafio/android/domain/entity/User.kt
+++ b/app/src/main/java/com/picpay/desafio/android/domain/entity/User.kt
@@ -1,8 +1,8 @@
 package com.picpay.desafio.android.domain.entity
 
 data class User(
-    val img: String?,
-    val name: String,
     val id: Int,
+    val img: String,
+    val name: String,
     val username: String
 )

--- a/app/src/test/java/com/picpay/desafio/android/utils/FakeModels.kt
+++ b/app/src/test/java/com/picpay/desafio/android/utils/FakeModels.kt
@@ -11,61 +11,61 @@ object FakeModels {
     val FAKE_CONTACTS_RESPONSE = listOf(
         UserResponse(
             id = 1,
-            img = "",
-            name = "",
-            username = ""
+            img = "test",
+            name = "João Souza",
+            username = "Souza"
         ),
         UserResponse(
-            id = 1,
+            id = 2,
             img = "",
-            name = "",
-            username = ""
+            name = null,
+            username = null
         ),
         UserResponse(
-            id = 1,
-            img = "",
-            name = "",
-            username = ""
+            id = 3,
+            img = " ",
+            name = null,
+            username = null
         )
     )
     val FAKE_CONTACTS_LOCAL = listOf(
         UserLocal(
             id = 1,
-            img = "",
-            name = "",
-            username = ""
+            img = "test",
+            name = "João Souza",
+            username = "Souza"
         ),
         UserLocal(
-            id = 1,
-            img = "",
-            name = "",
-            username = ""
+            id = 2,
+            img = "Empty image url",
+            name = "Empty name",
+            username = "Empty username"
         ),
         UserLocal(
-            id = 1,
-            img = "",
-            name = "",
-            username = ""
+            id = 3,
+            img = "Empty image url",
+            name = "Empty name",
+            username = "Empty username"
         )
     )
     val FAKE_CONTACTS = listOf(
         User(
             id = 1,
-            img = "",
-            name = "",
-            username = ""
+            img = "test",
+            name = "João Souza",
+            username = "Souza"
         ),
         User(
-            id = 1,
-            img = "",
-            name = "",
-            username = ""
+            id = 2,
+            img = "Empty image url",
+            name = "Empty name",
+            username = "Empty username"
         ),
         User(
-            id = 1,
-            img = "",
-            name = "",
-            username = ""
+            id = 3,
+            img = "Empty image url",
+            name = "Empty name",
+            username = "Empty username"
         )
     )
     val SUCCESS_CONTACTS_CALL = ResponseHandler.Success(FAKE_CONTACTS)


### PR DESCRIPTION
Adjusted return type of local, domain and response models to deal with null values... The main objective was following the famous phrase: "Simply do not return or pass `null`" from Clean Code book.
Adjusted fake model for unit tests too.